### PR TITLE
Made the script neater (along with correcting MP_POTION_LEVEL_LOCK)

### DIFF
--- a/Automated FCV scripts/Experience and Mana Potions
+++ b/Automated FCV scripts/Experience and Mana Potions
@@ -4,15 +4,15 @@
 /* ========================================== */
 /* [Users] Required script data to fill in    */
 /* ========================================== */
-const USER_ID = "PasteYourUserIdHere";
-const API_TOKEN = "PasteYourApiTokenHere"; // Do not share this to anyone
-const WEB_APP_URL = "PasteGeneratedWebAppUrlHere";
+const USER_ID = "PasteYourUserIdHere"
+const API_TOKEN = "PasteYourApiTokenHere" // Do not share this to anyone
+const WEB_APP_URL = "PasteGeneratedWebAppUrlHere"
 
 /* ========================================== */
 /* [Users] Required customizations to fill in */
 /* ========================================== */
-const CREATE_EXPERIENCE_POTION = 1; // Change this 1 to a 0 if you don't want the Experience Potion
-const CREATE_MANA_POTION = 1; // Change this 1 to a 0 if you don't want the Mana Potion
+const CREATE_EXPERIENCE_POTION = 1 // Change this 1 to a 0 if you don't want the Experience Potion
+const CREATE_MANA_POTION = 1 // Change this 1 to a 0 if you don't want the Mana Potion
 
 /* ========================================== */
 /* [Users] Optional customizations to fill in */
@@ -20,46 +20,51 @@ const CREATE_MANA_POTION = 1; // Change this 1 to a 0 if you don't want the Mana
 
 // Do you want to get private message notifications? (examples include if you're already at max Mana or exceeded the limit for daily potion usage) 
 // If you don't want them, change the 1 to a 0 in the line below
-const NOTIFICATIONS_ON = 1; 
+const NOTIFICATIONS_ON = 1
 
 /* ========================================== */
 /* [Users] Do not edit code below this line   */
 /* ========================================== */
-const AUTHOR_ID = "0034eb14-b4d8-494e-8386-d3f33cff7922";
-const SCRIPT_NAME = "Experience and Mana Potions";
+const AUTHOR_ID = "0034eb14-b4d8-494e-8386-d3f33cff7922"
+const SCRIPT_NAME = "Experience and Mana Potions"
 const HEADERS = {
   "x-client" : AUTHOR_ID + " - " + SCRIPT_NAME,
   "x-api-user" : USER_ID,
   "x-api-key" : API_TOKEN,
 }
 
-const scriptProperties = PropertiesService.getScriptProperties(); // Constants can have properties changed
+const scriptProperties = PropertiesService.getScriptProperties() // Constants can have properties changed
 
-const XP_POTION_TEXT = "**Experience Potion** ![Yellow potion](https://raw.githubusercontent.com/mike-the-monk/Habitica-customizations/main/Automated%20FCV%20scripts/images/experience%20potion%20large%20transparent%20wide%20432.png)";
-const XP_POTION_ALIAS = "XPpotion";
-const XP_POTION_NOTES = "Gain 150 Experience (Instant Use). Maximum per day: no more than 1/3 of what's needed to level up.";
-const XP_POTION_VALUE = "25";
-const XP_POTION_LEVEL_LOCK = 21;
-const MSG_XP_POTION_LEVEL_LOCK_FAIL = "You must be at least level 21 to use this potion.";
-const MSG_XP_POTION_DAILY_USAGE_EXCEEDED = "You've already gained your maximum allowable XP from potions today.";
+const XP_POTION_TEXT = "**Experience Potion** ![Yellow potion](https://raw.githubusercontent.com/mike-the-monk/Habitica-customizations/main/Automated%20FCV%20scripts/images/experience%20potion%20large%20transparent%20wide%20432.png)"
+const XP_POTION_ALIAS = "XPpotion"
+const XP_POTION_COST = 25
+const XP_CONVERSION_RATE = 6
+const XP_GAIN = XP_CONVERSION_RATE * XP_POTION_COST
+const MAX_DAILY_XP_POTION_USAGE = "1/3"
+const XP_POTION_NOTES = "Gain "+XP_GAIN+" Experience (Instant Use). Maximum per day: no more than "+MAX_DAILY_XP_POTION_USAGE+" of what's needed to level up."
+const XP_POTION_LEVEL_LOCK = 21
+const MSG_XP_POTION_LEVEL_LOCK_FAIL = "You must be at least level "+XP_POTION_LEVEL_LOCK+" to use this potion."
+const MSG_XP_POTION_DAILY_USAGE_EXCEEDED = "You've already gained your maximum allowable XP from potions today."
 
-const MP_POTION_TEXT = "**Mana Potion** ![Blue potion](https://raw.githubusercontent.com/mike-the-monk/Habitica-customizations/main/Automated%20FCV%20scripts/images/mana%20potion%20large%20transparent%20wide%20432.png)";
-const MP_POTION_ALIAS = "MPpotion";
-const MP_POTION_NOTES = "Recover 30 Mana (Instant Use). Maximum 4 per day."
-const MP_POTION_VALUE = "25";
-const MP_POTION_LEVEL_LOCK = 16;
-const MSG_MP_POTION_LEVEL_LOCK_FAIL = "You must be at least level 11 to use this potion.";
-const MAX_DAILY_MP_POTION_USAGE = 4;
-const MSG_MP_POTION_DAILY_USAGE_EXCEEDED = "You can only use this potion four times each day.";
-const MSG_ALREADY_AT_MAX_MANA = "You are already have maximum mana. This potion had no effect and did not count towards your daily limit of 4 potions."
-const MSG_NEAR_MAX_MANA = "This potion filled you to maximum Mana, but not beyond the max.";
+const MP_POTION_TEXT = "**Mana Potion** ![Blue potion](https://raw.githubusercontent.com/mike-the-monk/Habitica-customizations/main/Automated%20FCV%20scripts/images/mana%20potion%20large%20transparent%20wide%20432.png)"
+const MP_POTION_ALIAS = "MPpotion"
+const MP_POTION_COST = 25
+const MP_CONVERSION_RATE = 1.2
+const MP_GAIN = MP_CONVERSION_RATE * MP_POTION_COST
+const MAX_DAILY_MP_POTION_USAGE = 4
+const MP_POTION_NOTES = "Recover "+MP_GAIN+" Mana (Instant Use). Maximum "+MAX_DAILY_MP_POTION_USAGE+" per day."
+const MP_POTION_LEVEL_LOCK = 11
+const MSG_MP_POTION_LEVEL_LOCK_FAIL = "You must be at least level "+MP_POTION_LEVEL_LOCK+" to use this potion."
+const MSG_MP_POTION_DAILY_USAGE_EXCEEDED = "You can only use this potion "+MAX_DAILY_MP_POTION_USAGE+" times each day."
+const MSG_ALREADY_AT_MAX_MANA = "You are already have maximum mana. This potion had no effect and did not count towards your daily limit of "+MAX_DAILY_MP_POTION_USAGE+" potions."
+const MSG_NEAR_MAX_MANA = "This potion filled you to maximum Mana, but not beyond the max."
 
 const XP_POTION_BUTTON = {
     "text": XP_POTION_TEXT,
     "type": "reward",
     "alias": XP_POTION_ALIAS,
     "notes": XP_POTION_NOTES,
-    "value": XP_POTION_VALUE,
+    "value": XP_POTION_COST,
 }
 
 const MP_POTION_BUTTON = {
@@ -67,28 +72,28 @@ const MP_POTION_BUTTON = {
     "type": "reward",
     "alias": MP_POTION_ALIAS,
     "notes": MP_POTION_NOTES,
-    "value": MP_POTION_VALUE,
+    "value": MP_POTION_COST,
 }
 
-const CRON_COUNT_KEY = "CRON_COUNT_KEY";
-const XP_USAGE_KEY = "XP_USAGE_KEY";
-const MP_USAGE_KEY = "MP_USAGE_KEY";
-const TIMESTAMP_KEY = "TIMESTAMP_KEY";
+const CRON_COUNT_KEY = "CRON_COUNT_KEY"
+const XP_USAGE_KEY = "XP_USAGE_KEY"
+const MP_USAGE_KEY = "MP_USAGE_KEY"
+const TIMESTAMP_KEY = "TIMESTAMP_KEY"
 
-var cronCountKey = "";
-var xpUsageKey = "";
-var mpUsageKey = "";
-var timestampKey = "";
+var cronCountKey = ""
+var xpUsageKey = ""
+var mpUsageKey = ""
+var timestampKey = ""
 
 function doOneTimeSetup() {
   if ((CREATE_EXPERIENCE_POTION == 1) && (CREATE_MANA_POTION == 1)) {
-    api_createNewTaskForUser([MP_POTION_BUTTON, XP_POTION_BUTTON]);
+    api_createNewTaskForUser([MP_POTION_BUTTON, XP_POTION_BUTTON])
   }
   else if ((CREATE_EXPERIENCE_POTION == 1) && (CREATE_MANA_POTION == 0)) {
-    api_createNewTaskForUser([XP_POTION_BUTTON]);
+    api_createNewTaskForUser([XP_POTION_BUTTON])
   }
   else if ((CREATE_EXPERIENCE_POTION == 0) && (CREATE_MANA_POTION == 1)) {
-    api_createNewTaskForUser([MP_POTION_BUTTON]);
+    api_createNewTaskForUser([MP_POTION_BUTTON])
   }
   
   // Next, create the webhook
@@ -101,98 +106,98 @@ function doOneTimeSetup() {
     "type" : "taskActivity",
     "options" : options,
   }
-  apiMult_createNewWebhookNoDuplicates(payload);
+  apiMult_createNewWebhookNoDuplicates(payload)
   
   // set script properties so they carry over to next session
-  initScriptProperties();
+  initScriptProperties()
 }
 
 // do things when the webhook runs
 function doPost(e) {
-  const dataContents = JSON.parse(e.postData.contents);
-  const type = dataContents.type;
-  const task = dataContents.task;
+  const dataContents = JSON.parse(e.postData.contents)
+  const type = dataContents.type
+  const task = dataContents.task
   
   // Sanitize task alias
-  let sanitizedAlias = "sanitized"; // This will be the value if undefined, null, or blank
+  let sanitizedAlias = "sanitized" // This will be the value if undefined, null, or blank
   if ( (task.alias != undefined) && (task.alias != null) && (task.alias != "") ) {
-    sanitizedAlias = task.alias;
+    sanitizedAlias = task.alias
   }
   
   // Check if a task was scored and if it was the either alias 
   if ((type == "scored") && ( (sanitizedAlias == XP_POTION_ALIAS) || (sanitizedAlias == MP_POTION_ALIAS) ) ) {   
-    var timestampKey = TIMESTAMP_KEY;
-    var timeStart = Number(scriptProperties.getProperty(timestampKey));
+    var timestampKey = TIMESTAMP_KEY
+    var timeStart = Number(scriptProperties.getProperty(timestampKey))
     if ( (timeStart == 0) || (timeStart == "") || (timeStart == undefined) || (timeStart == null) ) {
-      timeStart = Date.now();
+      timeStart = Date.now()
     }
-    var timeEnd = Date.now();
+    var timeEnd = Date.now()
     
     // Rate limiting: If it's been less than 30 seconds since they last clicked one of these buttons, do nothing
     if ( (timeEnd - timeStart) >= 30000 ) {
-      const response = api_getAuthenticatedUserProfile("stats,items.gear.equipped");
-      user = JSON.parse(response).data;
+      const response = api_getAuthenticatedUserProfile("stats,items.gear.equipped")
+      user = JSON.parse(response).data
     
-      var cronCountKey = CRON_COUNT_KEY;
-      var xpUsageKey = XP_USAGE_KEY;
-      var mpUsageKey = MP_USAGE_KEY;
+      var cronCountKey = CRON_COUNT_KEY
+      var xpUsageKey = XP_USAGE_KEY
+      var mpUsageKey = MP_USAGE_KEY
     
-      var cronCount = Number(scriptProperties.getProperty(cronCountKey));
-      var xpUsage = Number(scriptProperties.getProperty(xpUsageKey));
-      var mpUsage = Number(scriptProperties.getProperty(mpUsageKey));
+      var cronCount = Number(scriptProperties.getProperty(cronCountKey))
+      var xpUsage = Number(scriptProperties.getProperty(xpUsageKey))
+      var mpUsage = Number(scriptProperties.getProperty(mpUsageKey))
     
-      let exp = user.stats.exp;
-      let mp = user.stats.mp;
-      let gp = user.stats.gp;
-      let lvl = user.stats.lvl;
+      let exp = user.stats.exp
+      let mp = user.stats.mp
+      let gp = user.stats.gp
+      let lvl = user.stats.lvl
     
       // If they've Cronned, reset all counters
       if (cronCount != user.flags.cronCount) {
-        cronCount = user.flags.cronCount;
-        resetCounters();
+        cronCount = user.flags.cronCount
+        resetCounters()
         
         // Save to non-volatile memory
-        scriptProperties.setProperty(cronCountKey, cronCount);
+        scriptProperties.setProperty(cronCountKey, cronCount)
       }
       
       // Switch-case based on which button was pressed. All button-click actions are in a separate function.
       switch (sanitizedAlias){
         case XP_POTION_ALIAS:
-          doButtonXpPotion(lvl, gp, exp, xpUsage, xpUsageKey);
-          break;
+          doButtonXpPotion(lvl, gp, exp, xpUsage, xpUsageKey)
+          break
         case MP_POTION_ALIAS:
-          doButtonMpPotion(lvl, gp, mp, mpUsage, mpUsageKey);
-          break;
+          doButtonMpPotion(lvl, gp, mp, mpUsage, mpUsageKey)
+          break
       }
 
       // Save values to non-volatile memory, but only from within the rate-limited if-block (we don't want to save the timestamp unless the script ran)
-      timeStart = timeEnd;
-      scriptProperties.setProperty(timestampKey, timeStart);
+      timeStart = timeEnd
+      scriptProperties.setProperty(timestampKey, timeStart)
     }
   }
-  return HtmlService.createHtmlOutput();
+  return HtmlService.createHtmlOutput()
 }
 
 // When the XP Potion button is clicked
 function doButtonXpPotion(lvl, gp, exp, xpUsage, xpUsageKey){
-  let XpToNextLevel = Math.round((Math.pow(lvl, 2) * 0.25 + 10 * lvl + 139.75) / 10) * 10;
-  let MaxDailyXpUsage = Math.floor(XpToNextLevel / 3);
+  let XpToNextLevel = Math.round((Math.pow(lvl, 2) * 0.25 + 10 * lvl + 139.75) / 10) * 10
+  let MaxDailyXpUsage = Math.floor(XpToNextLevel * eval(MAX_DAILY_XP_POTION_USAGE))
 
   // If level lock fails, refund the money and send failure message
-  let sufficientLevel = checkLevelLock(lvl, XP_POTION_LEVEL_LOCK, MSG_XP_POTION_LEVEL_LOCK_FAIL);
+  let sufficientLevel = checkLevelLock(lvl, XP_POTION_LEVEL_LOCK, MSG_XP_POTION_LEVEL_LOCK_FAIL)
   if (!sufficientLevel) {
-    api_updateUser({"stats.gp" : gp + 25}); 
+    api_updateUser({"stats.gp" : gp + XP_POTION_COST}) 
   } else {
-    // If another potion (+150 XP) would put them above the max, refund the money and send failure message
-    let usageLimitOkay = checkUsageLimit(xpUsage, 150, MaxDailyXpUsage, MSG_XP_POTION_DAILY_USAGE_EXCEEDED);
+    // If another potion (+XP_GAIN XP) would put them above the max, refund the money and send failure message
+    let usageLimitOkay = checkUsageLimit(xpUsage, XP_GAIN, MaxDailyXpUsage, MSG_XP_POTION_DAILY_USAGE_EXCEEDED)
     if (!usageLimitOkay) {
-      api_updateUser({"stats.gp" : gp + 25}); 
+      api_updateUser({"stats.gp" : gp + XP_POTION_COST}) 
     } else { // If another potion wouldn't make them exceed the max, run as normal and increment counter
-      api_updateUser({"stats.exp" : exp + 150});
-      xpUsage += 150;
+      api_updateUser({"stats.exp" : exp + XP_GAIN})
+      xpUsage += XP_GAIN
       
       // Save new counter value since it's updated
-      scriptProperties.setProperty(xpUsageKey, xpUsage);
+      scriptProperties.setProperty(xpUsageKey, xpUsage)
     }
   }
 }
@@ -200,46 +205,46 @@ function doButtonXpPotion(lvl, gp, exp, xpUsage, xpUsageKey){
 // When the MP Potion button is clicked
 function doButtonMpPotion(lvl, gp, mp, mpUsage, mpUsageKey){
   // Get equipment stats info
-  const responseContent = apiFree_getAllAvailableContentObjects();
-  content = JSON.parse(responseContent).data;
+  const responseContent = apiFree_getAllAvailableContentObjects()
+  content = JSON.parse(responseContent).data
 
   // Compute total Intelligence
-  let int = calculateIntelligence();
+  let int = calculateIntelligence()
 
-  let maxMp = (2 * int) + 30;
-  let mpDiff = maxMp - mp;
+  let maxMp = (2 * int) + 30
+  let mpDiff = maxMp - mp
 
   // If level lock fails, refund the money and send failure message
-  let sufficientLevel = checkLevelLock(lvl, MP_POTION_LEVEL_LOCK, MSG_MP_POTION_LEVEL_LOCK_FAIL);
+  let sufficientLevel = checkLevelLock(lvl, MP_POTION_LEVEL_LOCK, MSG_MP_POTION_LEVEL_LOCK_FAIL)
   if (!sufficientLevel) {
-    api_updateUser({"stats.gp" : gp + 25}); 
+    api_updateUser({"stats.gp" : gp + MP_POTION_COST}) 
   } else {
     // Check if they've exceeded daily usage. If yes, refund the money and send failure message
-    let usageLimitOkay = checkUsageLimit(mpUsage, 1, MAX_DAILY_MP_POTION_USAGE, MSG_MP_POTION_DAILY_USAGE_EXCEEDED);
+    let usageLimitOkay = checkUsageLimit(mpUsage, 1, MAX_DAILY_MP_POTION_USAGE, MSG_MP_POTION_DAILY_USAGE_EXCEEDED)
     if (!usageLimitOkay) {
-      api_updateUser({"stats.gp" : gp + 25}); 
+      api_updateUser({"stats.gp" : gp + MP_POTION_COST}) 
     } else {
       // Check if they're already at maximum mana. If yes, refund the money and send failure message
       if (mpDiff <= 0) {
-        api_updateUser({"stats.gp" : gp + 25}); 
-        api_sendPrivateMessage({"message" : MSG_ALREADY_AT_MAX_MANA, "toUserId" : USER_ID});
+        api_updateUser({"stats.gp" : gp + MP_POTION_COST}) 
+        api_sendPrivateMessage({"message" : MSG_ALREADY_AT_MAX_MANA, "toUserId" : USER_ID})
       }
       // Check if they're close to maximum mana. If yes, refill them to max but not beyond, and send a message
-      else if (mpDiff <= 30) {
-        api_updateUser({"stats.mp" : mp + mpDiff});
-        mpUsage++;
-        api_sendPrivateMessage({"message" : MSG_NEAR_MAX_MANA, "toUserId" : USER_ID});
+      else if (mpDiff <= MP_GAIN) {
+        api_updateUser({"stats.mp" : mp + mpDiff})
+        mpUsage++
+        api_sendPrivateMessage({"message" : MSG_NEAR_MAX_MANA, "toUserId" : USER_ID})
         
         // Save new counter value since it's updated
-        scriptProperties.setProperty(mpUsageKey, mpUsage);
+        scriptProperties.setProperty(mpUsageKey, mpUsage)
       }
-      // Run as normal if they're further than 30 MP away from maximum
-      else if (mpDiff > 30) {
-        api_updateUser({"stats.mp" : mp + 30});
-        mpUsage ++;
+      // Run as normal if they're further than MP_GAIN MP away from maximum
+      else if (mpDiff > MP_GAIN) {
+        api_updateUser({"stats.mp" : mp + MP_GAIN})
+        mpUsage ++
         
         // Save new counter value since it's updated
-        scriptProperties.setProperty(mpUsageKey, mpUsage);
+        scriptProperties.setProperty(mpUsageKey, mpUsage)
       }
     }
   }
@@ -255,24 +260,24 @@ function api_createNewTaskForUser(payload) {
     "muteHttpExceptions" : true,
   }
 
-  var url = "https://habitica.com/api/v3/tasks/user";
-  UrlFetchApp.fetch(url, params);
+  var url = "https://habitica.com/api/v3/tasks/user"
+  UrlFetchApp.fetch(url, params)
 }
 
 // Create a webhook if no duplicate exists
 function apiMult_createNewWebhookNoDuplicates(payload) {
-  const response = api_getWebhooks();
-  const webhooks = JSON.parse(response).data;
-  var duplicateExists = 0;
+  const response = api_getWebhooks()
+  const webhooks = JSON.parse(response).data
+  var duplicateExists = 0
     
   for (var i in webhooks) {
     if (webhooks[i].label == payload.label) {
-      duplicateExists = 1;
+      duplicateExists = 1
     }
   }
   // If webhook to be created doesn't exist yet
   if (!duplicateExists) {
-    api_createNewWebhook(payload);
+    api_createNewWebhook(payload)
   }
 }
 
@@ -284,8 +289,8 @@ function api_getWebhooks() {
     "muteHttpExceptions" : true,
   }
   
-  const url = "https://habitica.com/api/v3/user/webhook";
-  return UrlFetchApp.fetch(url, params);
+  const url = "https://habitica.com/api/v3/user/webhook"
+  return UrlFetchApp.fetch(url, params)
 }
 
 // Creates a webhook (as part of the "don't make it if there's a duplicate" function)
@@ -298,17 +303,17 @@ function api_createNewWebhook(payload) {
     "muteHttpExceptions" : true,
   }
    
-  const url = "https://habitica.com/api/v3/user/webhook";
-  return UrlFetchApp.fetch(url, params);
+  const url = "https://habitica.com/api/v3/user/webhook"
+  return UrlFetchApp.fetch(url, params)
 }
 
 // Sets initial properties that will be used/saved later.
 function initScriptProperties() {
-  var timestampInit = Date.now();
-  scriptProperties.setProperty(CRON_COUNT_KEY, 0);
-  scriptProperties.setProperty(XP_USAGE_KEY, 0);
-  scriptProperties.setProperty(MP_USAGE_KEY, 0);
-  scriptProperties.setProperty(TIMESTAMP_KEY, timestampInit);
+  var timestampInit = Date.now()
+  scriptProperties.setProperty(CRON_COUNT_KEY, 0)
+  scriptProperties.setProperty(XP_USAGE_KEY, 0)
+  scriptProperties.setProperty(MP_USAGE_KEY, 0)
+  scriptProperties.setProperty(TIMESTAMP_KEY, timestampInit)
 }
 
 // Gets user info so I can use it, especially stats like mana, experience, and level
@@ -319,12 +324,12 @@ function api_getAuthenticatedUserProfile(userFields) {
     "muteHttpExceptions" : true,
   }
   
-  var url = "https://habitica.com/api/v3/user";
+  var url = "https://habitica.com/api/v3/user"
   if (userFields != "") {
-    url += "?userFields=" + userFields;
+    url += "?userFields=" + userFields
   }
 
-  return UrlFetchApp.fetch(url, params);
+  return UrlFetchApp.fetch(url, params)
 }
 
 function apiFree_getAllAvailableContentObjects() {
@@ -333,8 +338,8 @@ function apiFree_getAllAvailableContentObjects() {
     "muteHttpExceptions" : true,
   }
   
-  const url = "https://habitica.com/api/v3/content";
-  return UrlFetchApp.fetch(url, params);
+  const url = "https://habitica.com/api/v3/content"
+  return UrlFetchApp.fetch(url, params)
 }
 
 // Changes stats
@@ -347,15 +352,15 @@ function api_updateUser(payload) {
     "muteHttpExceptions" : true,
   }
   
-  const url = "https://habitica.com/api/v3/user";
-  return UrlFetchApp.fetch(url, params);
+  const url = "https://habitica.com/api/v3/user"
+  return UrlFetchApp.fetch(url, params)
 }
 
 // Send a notification as a private message, only if they're enabled
 function api_sendPrivateMessage(payload) {
   switch (NOTIFICATIONS_ON){ // Check if notifications are on, send message if yes
         case 0:
-          break;        
+          break        
         case 1:
             const params = {
               "method" : "post",
@@ -364,69 +369,69 @@ function api_sendPrivateMessage(payload) {
               "payload" : JSON.stringify(payload),
               "muteHttpExceptions" : true,
             }
-            const url = "https://habitica.com/api/v3/members/send-private-message";
-            return UrlFetchApp.fetch(url, params);
-          break;
+            const url = "https://habitica.com/api/v3/members/send-private-message"
+            return UrlFetchApp.fetch(url, params)
+          break
   }
 }
 
 // Resets usage counters, usually done at Cron
 function resetCounters(){
-  scriptProperties.setProperty(XP_USAGE_KEY, 0);
-  scriptProperties.setProperty(MP_USAGE_KEY, 0);
+  scriptProperties.setProperty(XP_USAGE_KEY, 0)
+  scriptProperties.setProperty(MP_USAGE_KEY, 0)
 }
 
 function calculateIntelligence() {
-  const levelIntRaw = Math.floor(user.stats.lvl / 2);
-  const levelInt = (levelIntRaw > 50) ? 50 : levelIntRaw;
+  const levelIntRaw = Math.floor(user.stats.lvl / 2)
+  const levelInt = (levelIntRaw > 50) ? 50 : levelIntRaw
   
-  var totalEquipmentAndClassInt = 0;
-  const allocatedInt = user.stats.int;
-  const buffsInt = user.stats.buffs.int;
+  var totalEquipmentAndClassInt = 0
+  const allocatedInt = user.stats.int
+  const buffsInt = user.stats.buffs.int
   
   // Get INT from equipped gear
-  totalEquipmentAndClassInt += calcEquipmentAndClassInt(content.gear.flat[user.items.gear.equipped.weapon]);
-  totalEquipmentAndClassInt += calcEquipmentAndClassInt(content.gear.flat[user.items.gear.equipped.shield]);
-  totalEquipmentAndClassInt += calcEquipmentAndClassInt(content.gear.flat[user.items.gear.equipped.head]);
-  totalEquipmentAndClassInt += calcEquipmentAndClassInt(content.gear.flat[user.items.gear.equipped.armor]);
-  totalEquipmentAndClassInt += calcEquipmentAndClassInt(content.gear.flat[user.items.gear.equipped.headAccessory]);
-  totalEquipmentAndClassInt += calcEquipmentAndClassInt(content.gear.flat[user.items.gear.equipped.eyewear]);
-  totalEquipmentAndClassInt += calcEquipmentAndClassInt(content.gear.flat[user.items.gear.equipped.body]);
-  totalEquipmentAndClassInt += calcEquipmentAndClassInt(content.gear.flat[user.items.gear.equipped.back]);
+  totalEquipmentAndClassInt += calcEquipmentAndClassInt(content.gear.flat[user.items.gear.equipped.weapon])
+  totalEquipmentAndClassInt += calcEquipmentAndClassInt(content.gear.flat[user.items.gear.equipped.shield])
+  totalEquipmentAndClassInt += calcEquipmentAndClassInt(content.gear.flat[user.items.gear.equipped.head])
+  totalEquipmentAndClassInt += calcEquipmentAndClassInt(content.gear.flat[user.items.gear.equipped.armor])
+  totalEquipmentAndClassInt += calcEquipmentAndClassInt(content.gear.flat[user.items.gear.equipped.headAccessory])
+  totalEquipmentAndClassInt += calcEquipmentAndClassInt(content.gear.flat[user.items.gear.equipped.eyewear])
+  totalEquipmentAndClassInt += calcEquipmentAndClassInt(content.gear.flat[user.items.gear.equipped.body])
+  totalEquipmentAndClassInt += calcEquipmentAndClassInt(content.gear.flat[user.items.gear.equipped.back])
 
-  return levelInt + totalEquipmentAndClassInt + allocatedInt + buffsInt;
+  return levelInt + totalEquipmentAndClassInt + allocatedInt + buffsInt
 }
 
 function calcEquipmentAndClassInt(equipment) {
-  var equipmentAndClassInt = 0;
+  var equipmentAndClassInt = 0
 
   if (equipment != undefined) {  
-    equipmentAndClassInt += equipment.int;
+    equipmentAndClassInt += equipment.int
     if ( (equipment.klass == user.stats.class) || ( (equipment.klass == "special") && (equipment.specialClass == user.stats.class) ) ) {
-      equipmentAndClassInt += equipment.int / 2;
+      equipmentAndClassInt += equipment.int / 2
     }
   }
   
-  return equipmentAndClassInt;
+  return equipmentAndClassInt
 }
 
 // Check if sufficient level, send message if not.
 function checkLevelLock(level, levelLock, message){
   if (level < levelLock){
-    api_sendPrivateMessage({"message" : message, "toUserId" : USER_ID});
-    return false;
+    api_sendPrivateMessage({"message" : message, "toUserId" : USER_ID})
+    return false
   } else {
-    return true;
+    return true
   }
 }
 
 // Check if (daily) usage exceeded, send message if yes.
 function checkUsageLimit(usageCounter, newUsageIncrement, maxUsage, message){
   if ( (usageCounter + newUsageIncrement) > maxUsage ) {
-    api_sendPrivateMessage({"message" : message, "toUserId" : USER_ID});
-    return false;
+    api_sendPrivateMessage({"message" : message, "toUserId" : USER_ID})
+    return false
   } else {
-    return true;
+    return true
   }
 }
 
@@ -434,30 +439,30 @@ function checkUsageLimit(usageCounter, newUsageIncrement, maxUsage, message){
 
 // Manually reset usage counters
 function debugResetCounters() {
-  resetCounters();
+  resetCounters()
 }
 
 // Retrieves saved values and sends them in a private message
 function debugGetSavedValues(){
-  let cronCount = Number(scriptProperties.getProperty(CRON_COUNT_KEY));
-  let xpUsage = Number(scriptProperties.getProperty(XP_USAGE_KEY));
-  let mpUsage = Number(scriptProperties.getProperty(MP_USAGE_KEY));
+  let cronCount = Number(scriptProperties.getProperty(CRON_COUNT_KEY))
+  let xpUsage = Number(scriptProperties.getProperty(XP_USAGE_KEY))
+  let mpUsage = Number(scriptProperties.getProperty(MP_USAGE_KEY))
   
   // saving these will make my life easier
-  let MSG_JOINER_BEFORE = " is `";
-  let MSG_JOINER_AFTER = "`, "; 
+  let MSG_JOINER_BEFORE = " is `"
+  let MSG_JOINER_AFTER = "`, " 
   
   api_sendPrivateMessageAlways({"message" : "Saved values are as follows: cronCount is `" + cronCount + MSG_JOINER_AFTER
                                 + "xpUsage" + MSG_JOINER_BEFORE + xpUsage + MSG_JOINER_AFTER
-                                + "mpUsage" + MSG_JOINER_BEFORE + mpUsage + "`", "toUserId" : USER_ID});
+                                + "mpUsage" + MSG_JOINER_BEFORE + mpUsage + "`", "toUserId" : USER_ID})
 }
 
 // Mannually edits and saves the selected value (in case it saved incorrectly)
 function debugManuallyEditSavedValue() {
   // Fill them in below. xpUsage is shown as a sample.
-  let newValue = 0; 
-  let key = XP_USAGE_KEY;
+  let newValue = 0 
+  let key = XP_USAGE_KEY
   
   // Save
-  scriptProperties.setProperty(key, newValue);
+  scriptProperties.setProperty(key, newValue)
 }


### PR DESCRIPTION
1. Converted some repeating values to constants, e.g. XP potion cost, XP gain.
2. Stated the conversion rates (GP -> XP/MP).
3. Renamed potion value to potion cost for more clear meaning.
4. Removed all the semi-colons, none of them seemed needed.
5. Removed quotes around two integers.

(My previous pull request code change is also included in this, i.e. "Corrected the value of MP potion level lock")